### PR TITLE
AST-based ns form refactoring

### DIFF
--- a/autoload/hearth/lint/fix/refers.vim
+++ b/autoload/hearth/lint/fix/refers.vim
@@ -1,218 +1,47 @@
 
-func! s:parseNsForm(lines) " {{{
-    let nsStart = -1
-    let nsEnd = -1
-    let requireStart = -1
-    let requireEnd = -1
+func! s:createReferList(require, symbol)
+    " infer refer style
+    " TODO user preference for default?
+    let style = '[]'
+    if !empty(a:require)
+        for form in a:require.children
+            if form.type !=# 'vector'
+                continue
+            endif
 
-    let nesting = 0
-
-    for i in range(0, len(a:lines) - 1)
-        let line = a:lines[i]
-        let nesting += count(line, '(') - count(line, ')')
-
-        if line =~# '(:require\($\| \)'
-            let requireStart = i
-        endif
-        if requireStart >= 0 && line =~# '\])*[ ]*$'
-            let requireEnd = i
-        endif
-
-        if line =~# '(ns'
-            let nsStart = i
-        endif
-        if nsStart >= 0 && nesting == 0
-            let nsEnd = i
-            break
-        endif
-    endfor
-
-    return [nsStart, nsEnd, requireStart, requireEnd]
-endfunc " }}}
-
-func! s:chooseInsert(lines, ns, start, end) "{{{
-    " Choose the index within [start, end] of `lines`
-    " in which to insert an entry for `ns`
-
-    let depth = 0
-    let targetDepth = 0
-    let ns = a:ns
-
-    let insertAt = a:end
-    let indent = '            '  " default for top level of (:require)
-    let suffix = ''
-    let exists = 0
-
-    if a:lines[a:start] =~# ':require$' && a:end > a:start
-        " FIXME: there's probably a better way to infer the
-        " correct indent
-        let m = matchlist(a:lines[a:start + 1], '^\([ ]\+\)')
-        if len(m)
-            let indent = m[1]
-        endif
+            let refer = form.FindKeywordValue(':refer')
+            if !empty(refer)
+                if refer.type ==# 'form'
+                    let style = '()'
+                endif
+                break
+            endif
+        endfor
     endif
 
-    for i in range(a:start, a:end)
-        let line = a:lines[i]
-        let depth += count(line, '[') - count(line, ']')
+    return style[0] . a:symbol . style[1]
+endfunc
 
-        let m = matchlist(line, '\[\([a-zA-Z0-9_.-]*\)\>')
-        if empty(m)
-            continue
-        endif
-
-        let currentNs = m[1]
-
-        if ns == currentNs
-            let insertAt = i
-            let exists = 1
-            break
-        elseif ns < currentNs
-            let insertAt = i - 1
-            break
-        endif
-
-        if depth > targetDepth && stridx(ns, currentNs) == 0
-            " nested ns
-            let ns = ns[len(currentNs) + 1:]
-            let targetDepth = depth
-            continue
-        elseif depth > targetDepth
-            " unrelated nested ns form
-            continue
-        elseif depth < targetDepth
-            " only possible if we wanted a nested ns and ours belongs
-            " at the end of the list
-            " TODO this doesn't seem general enough
-            let a:lines[i] = substitute(a:lines[i], '\]\]\(\s*\|)*\)$', ']\1', '')
-            let suffix = ']'
-            let insertAt = i
-            break
-        endif
-    endfor
-
-    let indent .= repeat(' ', targetDepth)
-    return {
-        \ 'exists': exists,
-        \ 'indent': indent,
-        \ 'index': insertAt,
-        \ 'ns': ns,
-        \ 'suffix': suffix
-        \ }
-endfunc"}}}
-
-func! s:createForm(ns, mode, args)
+func! s:createForm(require, ns, mode, args)
     let form = '[' . a:ns
 
     if a:mode ==# 'as'
         let form .= ' :as ' . a:args[0]
     elseif a:mode ==# 'refer'
-        let form .= ' :refer [' . a:args[0] . ']'
+        let form .= ' :refer ' . s:createReferList(a:require, a:args[0])
     endif
 
     return form . ']'
 endfunc
-
-func! s:insertAs(line, alias)
-    if a:line =~# ' :as '
-        echom "There's already an alias for that namespace"
-        return
-    endif
-
-    let referIdx = stridx(a:line, ' :refer')
-    if referIdx != -1
-        return a:line[:referIdx] . ':as ' . a:alias . a:line[referIdx :]
-    endif
-
-    " presumably, the :refer is on the next line
-    return a:line . ' :as ' . a:alias
-endfunc
-
-func! s:insertRefer(line, symbol)
-    let m = matchlist(a:line, ':refer \[\([^\]]*\)')
-    if !empty(m)
-        " easy case; add to an existing refer
-        let items = split(m[1], '\s\+')
-        let newItems = sort(insert(items, a:symbol))
-        return substitute(a:line, m[1], join(newItems, ' '), '')
-    endif
-
-    " TODO the :refer could be on another line...
-
-    " insert the :refer after an :as, probably
-    let end = stridx(a:line, ']')
-    if end == -1
-        return a:line . ' :refer [' . a:symbol . ']'
-    endif
-
-    return a:line[:end-1] . ' :refer [' . a:symbol . ']' . a:line[end :]
-endfunc
-
-func! s:tryInsert(line, mode, args)
-    if a:mode ==# 'refer'
-        " insert a new refer for an existing ns
-        return s:insertRefer(a:line, a:args[0])
-
-    elseif a:mode ==# 'as'
-        " add :as to an existing :refer
-        return s:insertAs(a:line, a:args[0])
-    endif
-endfunc
-
-" func! hearth#lint#fix#refers#Insert(context, ns, mode, ...)
-"     " NOTE: this may be simpler to do from clojure...?
-"
-"     let lines = a:context.lines
-"
-"     let [nsStart, nsEnd, requireStart, requireEnd] = s:parseNsForm(lines)
-"     if requireStart < 0
-"         " no (:require) found; create it
-"         let lines[nsEnd] = substitute(lines[nsEnd], ')$', '', '')
-"         let form = s:createForm(a:ns, a:mode, a:000)
-"         return insert(lines, '  (:require ' . form . '))', nsEnd + 1)
-"     endif
-"
-"     " pick an appropriate place to insert
-"     let insert = s:chooseInsert(lines, a:ns, requireStart, requireEnd)
-"     let index = insert.index
-"     if insert.exists
-"         let inserted = s:tryInsert(lines[index], a:mode, a:000)
-"         if type(inserted) == v:t_string
-"             let lines[index] = inserted
-"             return lines
-"         endif
-"
-"         " already refer'd?
-"         return
-"     endif
-"
-"     let form = s:createForm(insert.ns, a:mode, a:000)
-"
-"     if index < requireStart
-"         " special case: inserting before the first require'd form
-"         let lines = insert(lines, '  (:require ' . form, index + 1)
-"         let lines[index + 2] = substitute(lines[index + 2], '(:require', '         ', '')
-"         return lines
-"     endif
-"
-"     let line = lines[index]
-"     let lines = insert(lines, insert.indent . form . insert.suffix, index + 1)
-"
-"     " if it's the last line, transfer the closing parens
-"     if line =~# ']))[ ]*$'
-"         let lines[index] = substitute(line, '))$', '', '')
-"         let lines[index + 1] .= '))'
-"     endif
-"
-"     return lines
-" endfunc
 
 func! hearth#lint#fix#refers#Insert(context, ns, mode, ...)
     let ast = hearth#util#ns_ast#Build(a:context.lines)
     let require = ast.FindClause(':require')
     if empty(require)
         " easy case; just add a new form
-        call ast.SortedInsertLiteral('(:require ' . s:createForm(a:ns, a:mode, a:000) . ')')
+        call ast.SortedInsertLiteral('(:require '
+            \. s:createForm(require, a:ns, a:mode, a:000)
+            \. ')')
         return hearth#util#ns_ast#ToLines(ast)
     endif
 
@@ -233,13 +62,14 @@ func! hearth#lint#fix#refers#Insert(context, ns, mode, ...)
 
     if empty(existingVector)
         " new reference; also pretty easy
-        call require.SortedInsertLiteral(s:createForm(ns, a:mode, a:000))
+        call require.SortedInsertLiteral(s:createForm(require, ns, a:mode, a:000))
         return hearth#util#ns_ast#ToLines(ast)
     endif
 
     if a:mode ==# 'as'
         if !empty(existingVector.FindKeywordValue(':as'))
             " existing alias already; do nothing
+            echom "There's already an alias for that namespace"
             return
         endif
 
@@ -247,7 +77,9 @@ func! hearth#lint#fix#refers#Insert(context, ns, mode, ...)
     elseif a:mode ==# 'refer'
         let refer = existingVector.FindKeywordValue(':refer')
         if empty(refer)
-            call existingVector.SortedAddKeyPair(':refer', '[' . a:1 . ']')
+            call existingVector.SortedAddKeyPair(
+                \ ':refer',
+                \ s:createReferList(require, a:1))
         else
             call refer.SortedInsertLiteral(a:1)
         endif

--- a/autoload/hearth/lint/fix/refers.vim
+++ b/autoload/hearth/lint/fix/refers.vim
@@ -206,3 +206,41 @@ func! hearth#lint#fix#refers#Insert(context, ns, mode, ...)
 
     return lines
 endfunc
+
+" func! hearth#lint#fix#refers#Insert(context, ns, mode, ...)
+"     let ast = hearth#util#ns_ast#Build(a:context.lines)
+"     let require = ast.FindClause(':require')
+"     if empty(require)
+"         " easy case; just add a new form
+"         call ast.SortedInsertLiteral('(:require ' . s:createForm(a:ns, a:mode, a:000) . ')')
+"         return hearth#util#ns_ast#ToLines(ast)
+"     endif
+"
+"     let existingVector = require.FindClause(a:ns)
+"     if empty(existingVector)
+"         " new reference; also pretty easy
+"         " TODO sorted insert
+"         call require.SortedInsertLiteral(s:createForm(a:ns, a:mode, a:000))
+"         return hearth#util#ns_ast#ToLines(ast)
+"     endif
+"
+"     " TODO nested insert
+"
+"     if a:mode ==# 'as'
+"         if !empty(require.FindKeywordValue(':as'))
+"             " existing alias already; do nothing
+"             return
+"         endif
+"
+"         call require.SortedAddKeyPair(':as', a:1)
+"     elseif a:mode ==# 'refer'
+"         let refer = existingVector.FindKeywordValue(':refer')
+"         if empty(refer)
+"             call existingVector.SortedAddKeyPair(':refer', '[' . a:1 . ']')
+"         else
+"             call refer.SortedInsertLiteral(a:1)
+"         endif
+"     endif
+"
+"     return hearth#util#ns_ast#ToLines(ast)
+" endfunc

--- a/autoload/hearth/lint/fix/refers.vim
+++ b/autoload/hearth/lint/fix/refers.vim
@@ -39,7 +39,7 @@ func! hearth#lint#fix#refers#Insert(context, ns, mode, ...)
     let require = ast.FindClause(':require')
     if empty(require)
         " easy case; just add a new form
-        call ast.SortedInsertLiteral('(:require '
+        call ast.InsertLiteral('(:require '
             \. s:createForm(require, a:ns, a:mode, a:000)
             \. ')')
         return hearth#util#ns_ast#ToLines(ast)
@@ -62,7 +62,7 @@ func! hearth#lint#fix#refers#Insert(context, ns, mode, ...)
 
     if empty(existingVector)
         " new reference; also pretty easy
-        call require.SortedInsertLiteral(s:createForm(require, ns, a:mode, a:000))
+        call require.InsertLiteral(s:createForm(require, ns, a:mode, a:000))
         return hearth#util#ns_ast#ToLines(ast)
     endif
 
@@ -73,15 +73,15 @@ func! hearth#lint#fix#refers#Insert(context, ns, mode, ...)
             return
         endif
 
-        call existingVector.SortedAddKeyPair(':as', a:1)
+        call existingVector.AddKeyPair(':as', a:1)
     elseif a:mode ==# 'refer'
         let refer = existingVector.FindKeywordValue(':refer')
         if empty(refer)
-            call existingVector.SortedAddKeyPair(
+            call existingVector.AddKeyPair(
                 \ ':refer',
                 \ s:createReferList(require, a:1))
         else
-            call refer.SortedInsertLiteral(a:1)
+            call refer.InsertLiteral(a:1)
         endif
     endif
 

--- a/autoload/hearth/util/ns_ast.vim
+++ b/autoload/hearth/util/ns_ast.vim
@@ -103,8 +103,12 @@ func! s:tokExpect(kind) dict
 endfunc
 
 func! s:tokThrow(message) dict
-    " TODO we could include some position info
-    throw a:message
+    let line = '(empty)'
+    if !empty(self.lines)
+        let line = self.lines[0]
+    endif
+    throw 'ERROR: ' . a:message
+        \. "\nAt col " . self.Col() . ': ' . line
 endfunc
 
 let s:tokenizer = {
@@ -147,9 +151,6 @@ func! s:isWhitespace(node) " {{{
 endfunc " }}}
 
 func! s:withChildren(node, children) " {{{
-    for child in a:children
-        let child.parent = a:node
-    endfor
     let a:node.children = a:children
     return a:node
 endfunc " }}}
@@ -210,7 +211,6 @@ endfunc
 " FORM {{{
 
 func! s:formSortedInsertLiteral(literal) dict " {{{
-    " TODO infer indent better?
     let newIndentCols = self.col + 2
     let length = len(self.children)
     if length < 2 || self.children[1].type ==# 'vector'

--- a/autoload/hearth/util/ns_ast.vim
+++ b/autoload/hearth/util/ns_ast.vim
@@ -112,16 +112,16 @@ func! s:tokThrow(message) dict
 endfunc
 
 let s:tokenizer = {
-            \ '_peeked': v:null,
-            \ 'col': 0,
-            \ 'hasPeek': function('s:tokHasPeek'),
-            \ 'stringLiteral': function('s:tokStringLiteral'),
-            \ 'Col': function('s:tokCol'),
-            \ 'Expect': function('s:tokExpect'),
-            \ 'Next': function('s:tokNext'),
-            \ 'Peek': function('s:tokPeek'),
-            \ 'Throw': function('s:tokThrow'),
-            \ }
+    \ '_peeked': v:null,
+    \ 'col': 0,
+    \ 'hasPeek': function('s:tokHasPeek'),
+    \ 'stringLiteral': function('s:tokStringLiteral'),
+    \ 'Col': function('s:tokCol'),
+    \ 'Expect': function('s:tokExpect'),
+    \ 'Next': function('s:tokNext'),
+    \ 'Peek': function('s:tokPeek'),
+    \ 'Throw': function('s:tokThrow'),
+    \ }
 
 func! hearth#util#ns_ast#tokenizer(lines)
     let tokenizer = deepcopy(s:tokenizer)
@@ -266,11 +266,11 @@ func! s:formToString() dict " {{{
 endfunc " }}}
 
 let s:form = {
-        \ 'type': 'form',
-        \ 'SortedInsertLiteral': function('s:formSortedInsertLiteral'),
-        \ 'FindClause': function('s:formFindClause'),
-        \ 'ToString': function('s:formToString'),
-        \ }
+    \ 'type': 'form',
+    \ 'SortedInsertLiteral': function('s:formSortedInsertLiteral'),
+    \ 'FindClause': function('s:formFindClause'),
+    \ 'ToString': function('s:formToString'),
+    \ }
 
 func! s:parseForm(tok) " {{{
     call a:tok.Expect('(')
@@ -412,13 +412,13 @@ func! s:vectorToString() dict " {{{
 endfunc " }}}
 
 let s:vector = {
-        \ 'type': 'vector',
-        \ 'FindKeywordValue': function('s:vectorFindKeywordValue'),
-        \ 'FindClause': function('s:vectorFindClause'),
-        \ 'SortedInsertLiteral': function('s:vectorSortedInsertLiteral'),
-        \ 'SortedAddKeyPair': function('s:vectorSortedAddKeyPair'),
-        \ 'ToString': function('s:vectorToString'),
-        \ }
+    \ 'type': 'vector',
+    \ 'FindKeywordValue': function('s:vectorFindKeywordValue'),
+    \ 'FindClause': function('s:vectorFindClause'),
+    \ 'SortedInsertLiteral': function('s:vectorSortedInsertLiteral'),
+    \ 'SortedAddKeyPair': function('s:vectorSortedAddKeyPair'),
+    \ 'ToString': function('s:vectorToString'),
+    \ }
 
 func! s:parseVector(tok) " {{{
     call a:tok.Expect('[')

--- a/autoload/hearth/util/ns_ast.vim
+++ b/autoload/hearth/util/ns_ast.vim
@@ -276,6 +276,38 @@ func! s:vectorFindKeywordValue(keyword) dict " {{{
     return v:null
 endfunc " }}}
 
+func! s:vectorSortedAddKeyPair(key, value) dict " {{{
+    " find sorted insert index
+    let index = 1  " assume there's an initial clause already
+    let length = len(self.children)
+    while index < length
+        let node = self.children[index]
+        if node.type ==# 'literal' && node.value[0] ==# ':' && node.value > a:key
+            break
+        endif
+        let index += 1
+    endwhile
+
+    " TODO should we insert newlines?
+
+    " insert whitespace if necessary
+    if index == length
+        let self.children = insert(self.children, s:createLiteral(' ', 'ws'), index)
+        let index += 1
+    endif
+
+    let self.children = extend(self.children, [
+        \ s:createLiteral(a:key),
+        \ s:createLiteral(' ', 'ws'),
+        \ s:createLiteral(a:value),
+        \ ], index)
+
+    " append whitespace if necessary
+    if index < length
+        let self.children = insert(self.children, s:createLiteral(' ', 'ws'), index + 3)
+    endif
+endfunc " }}}
+
 func! s:vectorSortedInsertLiteral(literal) dict " {{{
     " find sorted insert index
     let index = 0
@@ -311,6 +343,7 @@ let s:vector = {
         \ 'FindKeywordValue': function('s:vectorFindKeywordValue'),
         \ 'FindClause': function('s:vectorFindClause'),
         \ 'SortedInsertLiteral': function('s:vectorSortedInsertLiteral'),
+        \ 'SortedAddKeyPair': function('s:vectorSortedAddKeyPair'),
         \ 'ToString': function('s:vectorToString'),
         \ }
 

--- a/autoload/hearth/util/ns_ast.vim
+++ b/autoload/hearth/util/ns_ast.vim
@@ -11,9 +11,15 @@ let s:tokens = [
     \ ['sym', '^[^ )\]}]\+'],
     \ ]
 
+func! s:tokHasPeek() dict
+    return type(self._peeked) != type(v:null) || self._peeked != v:null
+endfunc
+
 func! s:tokStringLiteral() dict " {{{
     let self._lines[0] = self._lines[0][1:]
+    let self.col += 1
     let literal = ''
+
     while !empty(self._lines)
         let line = self._lines[0]
         let i = 0
@@ -21,6 +27,7 @@ func! s:tokStringLiteral() dict " {{{
         while i < length
             if line[i] ==# '"' && (i == 0 || line[i-1] !=# '\')
                 let literal .= line[0:i - 1]
+                let self.col += i + 1
                 let self._lines[0] = line[len(literal)+1:]
                 return ['string', literal]
             endif
@@ -30,20 +37,23 @@ func! s:tokStringLiteral() dict " {{{
         " couldn't find on this line; perhaps on the next?
         let literal .= line . "\n"
         let self._lines = self._lines[1:]
+        let self.col = 0
     endwhile
 
     throw 'Unterminated string: "' . literal
 endfunc " }}}
 
 func! s:tokNext() dict
-    if !(type(self._peeked) == type(v:null) && self._peeked == v:null)
+    if self.hasPeek()
         let next = self._peeked
         let self._peeked = v:null
+        let self._peekCol = -1
         return next
     endif
 
     while len(self._lines) && empty(self._lines[0])
         let self._lines = self._lines[1:]
+        let self.col = 0
         if !empty(self._lines)
             return ['ws', "\n"]
         endif
@@ -60,6 +70,7 @@ func! s:tokNext() dict
     for [kind, regex] in s:tokens
         let m = matchstr(line, regex)
         if !empty(m)
+            let self.col += len(m)
             let self._lines[0] = self._lines[0][len(m):]
             return [kind, m]
         endif
@@ -68,8 +79,16 @@ func! s:tokNext() dict
     throw 'Parse error; unexpected: ' . self._lines
 endfunc
 
+func! s:tokCol() dict
+    if self.hasPeek()
+        return self._peekCol
+    endif
+    return self.col
+endfunc
+
 func! s:tokPeek() dict
-    if type(self._peeked) == type(v:null) && self._peeked == v:null
+    if !self.hasPeek()
+        let self._peekCol = self.col
         let self._peeked = self.Next()
     endif
     return self._peeked
@@ -90,7 +109,10 @@ endfunc
 
 let s:tokenizer = {
             \ '_peeked': v:null,
+            \ 'col': 0,
+            \ 'hasPeek': function('s:tokHasPeek'),
             \ 'stringLiteral': function('s:tokStringLiteral'),
+            \ 'Col': function('s:tokCol'),
             \ 'Expect': function('s:tokExpect'),
             \ 'Next': function('s:tokNext'),
             \ 'Peek': function('s:tokPeek'),
@@ -121,14 +143,34 @@ let s:literal = {
 
 func! s:parseLiteral(tok)
     let [kind, value] = a:tok.Next()
-    return extend(deepcopy(s:literal), {'kind': kind, 'value': value})
+    return s:createLiteral(value, kind)
+endfunc
+
+func! s:createLiteral(value, ...)
+    let kind = a:0 ? a:1 : 'literal'
+    return extend(deepcopy(s:literal), {'kind': kind, 'value': a:value})
 endfunc
 
 " }}}
 
 " FORM {{{
 
-func! s:formFindClause(first) dict
+func! s:formAppend(literal) dict " {{{
+    " TODO infer indent better?
+    let newIndentCols = self.col + 2
+    if len(self.children) < 2 || self.children[1].type ==# 'vector'
+        let newIndentCols += len(self.first)
+    endif
+
+    let indent = repeat(' ', newIndentCols)
+    let self.children = extend(self.children, [
+        \ s:createLiteral("\n", 'ws'),
+        \ s:createLiteral(indent, 'ws'),
+        \ s:createLiteral(a:literal)
+        \ ])
+endfunc " }}}
+
+func! s:formFindClause(first) dict " {{{
     for child in self.children
         if child.type ==# 'form'
             if child.first ==# a:first
@@ -142,15 +184,16 @@ func! s:formFindClause(first) dict
         endif
     endfor
     return v:null
-endfunc
+endfunc " }}}
 
-func! s:formToString() dict
+func! s:formToString() dict " {{{
     let children = map(copy(self.children), 'v:val.ToString()')
     return '(' . self.first . join(children, '') . ')'
-endfunc
+endfunc " }}}
 
 let s:form = {
         \ 'type': 'form',
+        \ 'Append': function('s:formAppend'),
         \ 'FindClause': function('s:formFindClause'),
         \ 'ToString': function('s:formToString'),
         \ }
@@ -216,17 +259,20 @@ endfunc " }}}
 " }}}
 
 func! s:parse(tok)
+    let col = a:tok.Col()
     let [kind, next] = a:tok.Peek()
     if kind ==# '('
-        return s:parseForm(a:tok)
+        let result = s:parseForm(a:tok)
     elseif kind ==# '['
-        return s:parseVector(a:tok)
+        let result = s:parseVector(a:tok)
     else
-        return s:parseLiteral(a:tok)
+        let result = s:parseLiteral(a:tok)
     endif
+    let result.col = col
+    return result
 endfunc
 
 func! hearth#util#ns_ast#Build(lines)
     let tok = hearth#util#ns_ast#tokenizer(a:lines)
-    return s:parseForm(tok)
+    return s:parse(tok)
 endfunc

--- a/autoload/hearth/util/ns_ast.vim
+++ b/autoload/hearth/util/ns_ast.vim
@@ -352,22 +352,20 @@ func! s:vectorSortedAddKeyPair(key, value) dict " {{{
 
     " TODO should we insert newlines?
 
-    " insert whitespace if necessary
-    if index == length
-        let self.children = insert(self.children, s:createLiteral(' ', 'ws'), index)
-        let index += 1
-    endif
-
-    let self.children = extend(self.children, [
+    let toInsert = [
         \ s:createLiteral(a:key),
         \ s:createLiteral(' ', 'ws'),
         \ s:createLiteral(a:value),
-        \ ], index)
+        \ ]
 
-    " append whitespace if necessary
-    if index < length
-        let self.children = insert(self.children, s:createLiteral(' ', 'ws'), index + 3)
+    " insert or append whitespace if necessary
+    if index == length
+        let toInsert = insert(toInsert, s:createLiteral(' ', 'ws'), 0)
+    elseif index < length
+        let toInsert = add(toInsert, s:createLiteral(' ', 'ws'))
     endif
+
+    let self.children = extend(self.children, toInsert, index)
 endfunc " }}}
 
 func! s:vectorSortedInsertLiteral(literal) dict " {{{

--- a/autoload/hearth/util/ns_ast.vim
+++ b/autoload/hearth/util/ns_ast.vim
@@ -226,14 +226,9 @@ func! s:formSortedInsertLiteral(literal) dict " {{{
     endif
 
     " find the index to insert
-    let firstNonWhitespace = -1
     while index < length
         let node = self.children[index]
-        let isWhitespace = s:isWhitespace(node)
-        if !isWhitespace && firstNonWhitespace < 0
-            let firstNonWhitespace  = index
-        endif
-        if !isWhitespace && s:compare(a:literal, node)
+        if !s:isWhitespace(node) && s:compare(a:literal, node)
             break
         endif
         let index += 1
@@ -245,9 +240,8 @@ func! s:formSortedInsertLiteral(literal) dict " {{{
         \ ]
 
     let indentIndex = 0
-    if index <= firstNonWhitespace
-        " the first item doesn't need indenting before it; instead,
-        " indent any item that might previously have been first
+    if index < length
+        " indent after *unless* we're appending to the end
         let indentIndex = len(toAdd)
     endif
     let toAdd = extend(toAdd, [

--- a/autoload/hearth/util/ns_ast.vim
+++ b/autoload/hearth/util/ns_ast.vim
@@ -1,0 +1,199 @@
+
+" ======= Tokenizer ======================================= {{{
+
+let s:tokens = [
+    \ ['ws', '^\s\+'],
+    \ ['meta', '^\^'],
+    \ ['(', '^('], [')', '^)'],
+    \ ['{', '^{'], ['}', '^}'],
+    \ ['[', '^\['], [']', '^\]'],
+    \ ['kw', '^:[^ )\]}]\+'],
+    \ ['sym', '^[^ )\]}]\+'],
+    \ ]
+
+func! s:tokStringLiteral() dict " {{{
+    let self._lines[0] = self._lines[0][1:]
+    let literal = ''
+    while !empty(self._lines)
+        let line = self._lines[0]
+        let i = 0
+        let length = len(line)
+        while i < length
+            if line[i] ==# '"' && (i == 0 || line[i-1] !=# '\')
+                let literal .= line[0:i - 1]
+                let self._lines[0] = line[len(literal)+1:]
+                return ['string', literal]
+            endif
+            let i += 1
+        endwhile
+
+        " couldn't find on this line; perhaps on the next?
+        let literal .= line . "\n"
+        let self._lines = self._lines[1:]
+    endwhile
+
+    throw 'Unterminated string: "' . literal
+endfunc " }}}
+
+func! s:tokNext() dict
+    if !(type(self._peeked) == type(v:null) && self._peeked == v:null)
+        let next = self._peeked
+        let self._peeked = v:null
+        return next
+    endif
+
+    while len(self._lines) && empty(self._lines[0])
+        let self._lines = self._lines[1:]
+        if !empty(self._lines)
+            return ['ws', '\n']
+        endif
+    endwhile
+    if empty(self._lines)
+        return ['end', '']
+    endif
+
+    let line = self._lines[0]
+    if line[0] ==# '"'
+        return self.stringLiteral()
+    endif
+
+    for [kind, regex] in s:tokens
+        let m = matchstr(line, regex)
+        if !empty(m)
+            let self._lines[0] = self._lines[0][len(m):]
+            return [kind, m]
+        endif
+    endfor
+
+    throw 'Parse error; unexpected: ' . self._lines
+endfunc
+
+func! s:tokPeek() dict
+    if type(self._peeked) == type(v:null) && self._peeked == v:null
+        let self._peeked = self.Next()
+    endif
+    return self._peeked
+endfunc
+
+func! s:tokExpect(kind) dict
+    let next = self.Next()
+    if next[0] !=# a:kind
+        throw 'Expected ' . a:kind . ' but was: ' . string(next)
+    endif
+    return next
+endfunc
+
+func! s:tokThrow(message) dict
+    " TODO we could include some position info
+    throw a:message
+endfunc
+
+let s:tokenizer = {
+            \ '_peeked': v:null,
+            \ 'stringLiteral': function('s:tokStringLiteral'),
+            \ 'Expect': function('s:tokExpect'),
+            \ 'Next': function('s:tokNext'),
+            \ 'Peek': function('s:tokPeek'),
+            \ 'Throw': function('s:tokThrow'),
+            \ }
+
+func! hearth#util#ns_ast#tokenizer(lines)
+    let tokenizer = deepcopy(s:tokenizer)
+    let tokenizer._lines = a:lines
+    return tokenizer
+endfunc
+
+" }}}
+
+
+" ======= AST parsing =====================================
+
+" LITERAL {{{
+
+func! s:literalToString() dict
+    return self.value
+endfunc
+
+let s:literal = {
+    \ 'type': 'literal',
+    \ 'ToString': function('s:literalToString'),
+    \ }
+
+func! s:parseLiteral(tok)
+    let [kind, value] = a:tok.Next()
+    return extend(deepcopy(s:literal), {'kind': kind, 'value': value})
+endfunc
+
+" }}}
+
+" FORM {{{
+
+func! s:formFindClause(first) dict
+    for child in self.children
+        if child.type ==# 'form'
+            if child.first ==# a:first
+                return child
+            endif
+
+            let fromChild = child.FindClause(a:first)
+            if !empty(fromChild)
+                return fromChild
+            endif
+        endif
+    endfor
+    return v:null
+endfunc
+
+func! s:formToString() dict
+    let children = map(copy(self.children), 'v:val.ToString()')
+    return '(' . self.first . join(children, '') . ')'
+endfunc
+
+let s:form = {
+        \ 'type': 'form',
+        \ 'FindClause': function('s:formFindClause'),
+        \ 'ToString': function('s:formToString'),
+        \ }
+
+func! s:parseForm(tok) " {{{
+    call a:tok.Expect('(')
+
+    let [kind, first] = a:tok.Next()
+    if kind !=# 'sym' && kind !=# 'kw'
+        cal a:tok.Throw('Unexpected form first: ' . kind)
+    endif
+
+    let children = []
+    while 1
+        let [kind, next] = a:tok.Peek()
+        if kind ==# ')'
+            call a:tok.Next()
+            break
+        else
+            let children = add(children, s:parse(a:tok))
+        endif
+    endwhile
+
+    return extend(deepcopy(s:form), {
+        \ 'children': children,
+        \ 'first': first,
+        \ })
+endfunc " }}}
+
+" }}}
+
+func! s:parse(tok)
+    let [kind, next] = a:tok.Peek()
+    if kind ==# '('
+        return s:parseForm(a:tok)
+    elseif kind ==# '['
+        throw 'TODO vector'
+    else
+        return s:parseLiteral(a:tok)
+    endif
+endfunc
+
+func! hearth#util#ns_ast#Build(lines)
+    let tok = hearth#util#ns_ast#tokenizer(a:lines)
+    return s:parseForm(tok)
+endfunc

--- a/autoload/hearth/util/ns_ast.vim
+++ b/autoload/hearth/util/ns_ast.vim
@@ -210,7 +210,7 @@ endfunc
 
 " FORM {{{
 
-func! s:formSortedInsertLiteral(literal) dict " {{{
+func! s:formInsertLiteral(literal) dict " {{{
     let newIndentCols = self.col + 2
     let length = len(self.children)
     if length < 2 || self.children[1].type ==# 'vector'
@@ -267,7 +267,7 @@ endfunc " }}}
 
 let s:form = {
     \ 'type': 'form',
-    \ 'SortedInsertLiteral': function('s:formSortedInsertLiteral'),
+    \ 'InsertLiteral': function('s:formInsertLiteral'),
     \ 'FindClause': function('s:formFindClause'),
     \ 'ToString': function('s:formToString'),
     \ }
@@ -338,7 +338,7 @@ func! s:vectorFindKeywordValue(keyword) dict " {{{
     return v:null
 endfunc " }}}
 
-func! s:vectorSortedAddKeyPair(key, value) dict " {{{
+func! s:vectorAddKeyPair(key, value) dict " {{{
     " find sorted insert index
     let index = 1  " assume there's an initial clause already
     let length = len(self.children)
@@ -368,7 +368,7 @@ func! s:vectorSortedAddKeyPair(key, value) dict " {{{
     let self.children = extend(self.children, toInsert, index)
 endfunc " }}}
 
-func! s:vectorSortedInsertLiteral(literal) dict " {{{
+func! s:vectorInsertLiteral(literal) dict " {{{
     " find sorted insert index
     let index = 0
     let length = len(self.children)
@@ -413,8 +413,8 @@ let s:vector = {
     \ 'type': 'vector',
     \ 'FindKeywordValue': function('s:vectorFindKeywordValue'),
     \ 'FindClause': function('s:vectorFindClause'),
-    \ 'SortedInsertLiteral': function('s:vectorSortedInsertLiteral'),
-    \ 'SortedAddKeyPair': function('s:vectorSortedAddKeyPair'),
+    \ 'InsertLiteral': function('s:vectorInsertLiteral'),
+    \ 'AddKeyPair': function('s:vectorAddKeyPair'),
     \ 'ToString': function('s:vectorToString'),
     \ }
 

--- a/autoload/hearth/util/ns_ast.vim
+++ b/autoload/hearth/util/ns_ast.vim
@@ -258,7 +258,7 @@ endfunc " }}}
 
 " }}}
 
-func! s:parse(tok)
+func! s:parse(tok) " {{{
     let col = a:tok.Col()
     let [kind, next] = a:tok.Peek()
     if kind ==# '('
@@ -270,7 +270,7 @@ func! s:parse(tok)
     endif
     let result.col = col
     return result
-endfunc
+endfunc " }}}
 
 func! hearth#util#ns_ast#Build(lines)
     let tok = hearth#util#ns_ast#tokenizer(a:lines)

--- a/test/lint/fix/ns.vader
+++ b/test/lint/fix/ns.vader
@@ -206,3 +206,20 @@ Expect clojure (Nested insert in middle):
       [serenity
        [cargo :as cargo]
        [util :as util]]))
+
+
+"
+" =========================================================
+"
+
+Given clojure (Simple ns with existing paren-refer):
+  (ns serenity.core
+    (:require [serenity.util :refer (cry-baby)]))
+
+Execute (Add new paren-refer clause):
+  call InsertNs('serenity.cargo', 'refer', 'geisha-dolls')
+
+Expect clojure (Insert :as clause):
+  (ns serenity.core
+    (:require [serenity.cargo :refer (geisha-dolls)]
+              [serenity.util :refer (cry-baby)]))

--- a/test/util/ns_ast/ast-test.vader
+++ b/test/util/ns_ast/ast-test.vader
@@ -38,7 +38,6 @@ Execute (Build AST and find serenity.cargo require clause, :as arg):
   let vector = ast.FindClause('serenity.cargo')
   AssertEqual v:t_dict, type(vector)
   AssertEqual 'vector', vector.type
-  AssertEqual 'form', vector.parent.type
   AssertEqual 'cargo', vector.FindKeywordValue(':as').value
 
 

--- a/test/util/ns_ast/ast-test.vader
+++ b/test/util/ns_ast/ast-test.vader
@@ -1,0 +1,18 @@
+Execute (Provide util fns):
+  func! Build()
+    return hearth#util#ns_ast#Build(getline(0, line('$')))
+  endfunc
+
+"
+" =========================================================
+"
+
+Given clojure (Empty ns):
+  (ns serenity.core)
+
+Execute (Build AST):
+  let ast = Build()
+  AssertEqual 'form', ast.type
+  AssertEqual 'ns', ast.first
+  AssertEqual '(ns serenity.core)', ast.ToString()
+  AssertEqual v:null, ast.FindClause(':require')

--- a/test/util/ns_ast/ast-test.vader
+++ b/test/util/ns_ast/ast-test.vader
@@ -33,6 +33,22 @@ Given clojure (ns with single :require):
   (ns serenity.core
     (:require [serenity.cargo :as cargo]))
 
+Execute (Build AST and find serenity.cargo require clause):
+  let ast = Build()
+  let vector = ast.FindClause('serenity.cargo')
+  AssertEqual v:t_dict, type(vector)
+  AssertEqual 'vector', vector.type
+  AssertEqual 'form', vector.parent.type
+
+
+"
+" =========================================================
+"
+
+Given clojure (ns with single :require):
+  (ns serenity.core
+    (:require [serenity.cargo :as cargo]))
+
 Execute (Build AST):
   let ast = Build()
   AssertEqual 'form', ast.type

--- a/test/util/ns_ast/ast-test.vader
+++ b/test/util/ns_ast/ast-test.vader
@@ -89,3 +89,25 @@ Expect clojure (Properly indent new form):
               [serenity.util :as util]))
 
 
+"
+" =========================================================
+"
+
+Given clojure (Single :require ns on its own line):
+  (ns serenity.core
+    (:require
+      [serenity.cargo :as cargo]))
+
+Execute (Add vector to :require form):
+  let ast = Build()
+  let require = ast.FindClause(':require')
+  call require.Append('[serenity.util :as util]')
+  call Write(ast)
+
+Expect clojure (Properly indent new form):
+  (ns serenity.core
+    (:require
+      [serenity.cargo :as cargo]
+      [serenity.util :as util]))
+
+

--- a/test/util/ns_ast/ast-test.vader
+++ b/test/util/ns_ast/ast-test.vader
@@ -5,7 +5,7 @@ Execute (Provide util fns):
   func! Write(ast)
     " there ought to be a better way:
     norm ggdG
-    let lines = split(a:ast.ToString(), "\n", 1)
+    let lines = hearth#util#ns_ast#ToLines(a:ast)
     call append(0, lines)
     norm Gdd
   endfunc
@@ -78,7 +78,7 @@ Given clojure (Empty ns):
 
 Execute (Add :require form):
   let ast = Build()
-  call ast.Append('(:require [serenity.cargo :as cargo])')
+  call ast.SortedInsertLiteral('(:require [serenity.cargo :as cargo])')
   call Write(ast)
 
 Expect clojure (Properly indent new form):
@@ -94,10 +94,30 @@ Given clojure (Single :require ns):
   (ns serenity.core
     (:require [serenity.cargo :as cargo]))
 
-Execute (Add vector to :require form):
+Execute (Add vector to end of :require form):
   let ast = Build()
   let require = ast.FindClause(':require')
-  call require.Append('[serenity.util :as util]')
+  call require.SortedInsertLiteral('[serenity.util :as util]')
+  call Write(ast)
+
+Expect clojure (Properly indent new form):
+  (ns serenity.core
+    (:require [serenity.cargo :as cargo]
+              [serenity.util :as util]))
+
+
+"
+" =========================================================
+"
+
+Given clojure (Single :require ns):
+  (ns serenity.core
+    (:require [serenity.util :as util]))
+
+Execute (Add vector to beginning of :require form):
+  let ast = Build()
+  let require = ast.FindClause(':require')
+  call require.SortedInsertLiteral('[serenity.cargo :as cargo]')
   call Write(ast)
 
 Expect clojure (Properly indent new form):
@@ -115,10 +135,10 @@ Given clojure (Single :require ns on its own line):
     (:require
       [serenity.cargo :as cargo]))
 
-Execute (Add vector to :require form):
+Execute (Add vector to end of :require form):
   let ast = Build()
   let require = ast.FindClause(':require')
-  call require.Append('[serenity.util :as util]')
+  call require.SortedInsertLiteral('[serenity.util :as util]')
   call Write(ast)
 
 Expect clojure (Properly indent new form):

--- a/test/util/ns_ast/ast-test.vader
+++ b/test/util/ns_ast/ast-test.vader
@@ -2,6 +2,13 @@ Execute (Provide util fns):
   func! Build()
     return hearth#util#ns_ast#Build(getline(0, line('$')))
   endfunc
+  func! Write(ast)
+    " there ought to be a better way:
+    norm ggdG
+    let lines = split(a:ast.ToString(), "\n", 1)
+    call append(0, lines)
+    norm Gdd
+  endfunc
 
 "
 " =========================================================
@@ -16,3 +23,30 @@ Execute (Build AST):
   AssertEqual 'ns', ast.first
   AssertEqual '(ns serenity.core)', ast.ToString()
   AssertEqual v:null, ast.FindClause(':require')
+
+
+"
+" =========================================================
+"
+
+Given clojure (ns with single :require):
+  (ns serenity.core
+    (:require [serenity.cargo :as cargo]))
+
+Execute (Build AST):
+  let ast = Build()
+  AssertEqual 'form', ast.type
+  AssertEqual 'ns', ast.first
+  AssertEqual "\n", ast.children[2].value
+
+  let require = ast.FindClause(':require')
+  AssertEqual 'form', require.type
+  AssertEqual ':require', require.first
+  AssertEqual 2, len(require.children)
+  AssertEqual 'ws', require.children[0].kind
+  AssertEqual 'vector', require.children[1].type
+  call Write(ast)
+
+Expect clojure (Produce identical result):
+  (ns serenity.core
+    (:require [serenity.cargo :as cargo]))

--- a/test/util/ns_ast/ast-test.vader
+++ b/test/util/ns_ast/ast-test.vader
@@ -226,3 +226,48 @@ Execute (Sorted Insert of keyword clause):
 Expect clojure (Insert :as clause correctly):
   (ns serenity.core
     (:require [serenity.cargo :as cargo :refer [geisha-dolls]]))
+
+
+"
+" =========================================================
+"
+
+Given clojure (ns with single, nested :require):
+  (ns serenity.core
+    (:require [serenity
+               [util :as util]]))
+
+Execute (Insert vector into nested :require form):
+  let ast = Build()
+  let vector = ast.FindClause('serenity')
+  call vector.SortedInsertLiteral('[cargo :as cargo]')
+  call Write(ast)
+
+Expect clojure (Properly indent new form):
+  (ns serenity.core
+    (:require [serenity
+               [cargo :as cargo]
+               [util :as util]]))
+
+
+"
+" =========================================================
+"
+
+Given clojure (ns with single, nested :require):
+  (ns serenity.core
+    (:require [serenity
+               [cargo :as cargo]]))
+
+Execute (Append vector to nested :require form):
+  let ast = Build()
+  let vector = ast.FindClause('serenity')
+  call vector.SortedInsertLiteral('[util :as util]')
+  call Write(ast)
+
+Expect clojure (Properly indent new form):
+  (ns serenity.core
+    (:require [serenity
+               [cargo :as cargo]
+               [util :as util]]))
+

--- a/test/util/ns_ast/ast-test.vader
+++ b/test/util/ns_ast/ast-test.vader
@@ -50,3 +50,42 @@ Execute (Build AST):
 Expect clojure (Produce identical result):
   (ns serenity.core
     (:require [serenity.cargo :as cargo]))
+
+
+"
+" =========================================================
+"
+
+Given clojure (Empty ns):
+  (ns serenity.core)
+
+Execute (Add :require form):
+  let ast = Build()
+  call ast.Append('(:require [serenity.cargo :as cargo])')
+  call Write(ast)
+
+Expect clojure (Properly indent new form):
+  (ns serenity.core
+    (:require [serenity.cargo :as cargo]))
+
+
+"
+" =========================================================
+"
+
+Given clojure (Single :require ns):
+  (ns serenity.core
+    (:require [serenity.cargo :as cargo]))
+
+Execute (Add vector to :require form):
+  let ast = Build()
+  let require = ast.FindClause(':require')
+  call require.Append('[serenity.util :as util]')
+  call Write(ast)
+
+Expect clojure (Properly indent new form):
+  (ns serenity.core
+    (:require [serenity.cargo :as cargo]
+              [serenity.util :as util]))
+
+

--- a/test/util/ns_ast/ast-test.vader
+++ b/test/util/ns_ast/ast-test.vader
@@ -77,7 +77,7 @@ Given clojure (Empty ns):
 
 Execute (Add :require form):
   let ast = Build()
-  call ast.SortedInsertLiteral('(:require [serenity.cargo :as cargo])')
+  call ast.InsertLiteral('(:require [serenity.cargo :as cargo])')
   call Write(ast)
 
 Expect clojure (Properly indent new form):
@@ -96,7 +96,7 @@ Given clojure (Single :require ns):
 Execute (Add vector to end of :require form):
   let ast = Build()
   let require = ast.FindClause(':require')
-  call require.SortedInsertLiteral('[serenity.util :as util]')
+  call require.InsertLiteral('[serenity.util :as util]')
   call Write(ast)
 
 Expect clojure (Properly indent new form):
@@ -116,7 +116,7 @@ Given clojure (Single :require ns):
 Execute (Add vector to beginning of :require form):
   let ast = Build()
   let require = ast.FindClause(':require')
-  call require.SortedInsertLiteral('[serenity.cargo :as cargo]')
+  call require.InsertLiteral('[serenity.cargo :as cargo]')
   call Write(ast)
 
 Expect clojure (Properly indent new form):
@@ -137,7 +137,7 @@ Given clojure (Multi- :require ns):
 Execute (Add vector to middle of :require form):
   let ast = Build()
   let require = ast.FindClause(':require')
-  call require.SortedInsertLiteral('[serenity.cargo :as cargo]')
+  call require.InsertLiteral('[serenity.cargo :as cargo]')
   call Write(ast)
 
 Expect clojure (Properly indent new form):
@@ -159,7 +159,7 @@ Given clojure (Single :require ns on its own line):
 Execute (Add vector to end of :require form):
   let ast = Build()
   let require = ast.FindClause(':require')
-  call require.SortedInsertLiteral('[serenity.util :as util]')
+  call require.InsertLiteral('[serenity.util :as util]')
   call Write(ast)
 
 Expect clojure (Properly indent new form):
@@ -181,7 +181,7 @@ Execute (Sorted Insert of literal into a :refer vector at beginning):
   let ast = Build()
   let vector = ast.FindClause('serenity.cargo')
   let refer = vector.FindKeywordValue(':refer')
-  call refer.SortedInsertLiteral('beef')
+  call refer.InsertLiteral('beef')
   call Write(ast)
 
 Expect clojure (Properly indent new form):
@@ -200,7 +200,7 @@ Given clojure (ns with single :require and :as):
 Execute (Sorted Insert of keyword clause):
   let ast = Build()
   let vector = ast.FindClause('serenity.cargo')
-  call vector.SortedAddKeyPair(':refer', '[geisha-dolls]')
+  call vector.AddKeyPair(':refer', '[geisha-dolls]')
   call Write(ast)
 
 Expect clojure (Insert :refer clause correctly):
@@ -219,7 +219,7 @@ Given clojure (ns with single :require and :refer):
 Execute (Sorted Insert of keyword clause):
   let ast = Build()
   let vector = ast.FindClause('serenity.cargo')
-  call vector.SortedAddKeyPair(':as', 'cargo')
+  call vector.AddKeyPair(':as', 'cargo')
   call Write(ast)
 
 Expect clojure (Insert :as clause correctly):
@@ -239,7 +239,7 @@ Given clojure (ns with single, nested :require):
 Execute (Insert vector into nested :require form):
   let ast = Build()
   let vector = ast.FindClause('serenity')
-  call vector.SortedInsertLiteral('[cargo :as cargo]')
+  call vector.InsertLiteral('[cargo :as cargo]')
   call Write(ast)
 
 Expect clojure (Properly indent new form):
@@ -261,7 +261,7 @@ Given clojure (ns with single, nested :require):
 Execute (Append vector to nested :require form):
   let ast = Build()
   let vector = ast.FindClause('serenity')
-  call vector.SortedInsertLiteral('[util :as util]')
+  call vector.InsertLiteral('[util :as util]')
   call Write(ast)
 
 Expect clojure (Properly indent new form):

--- a/test/util/ns_ast/ast-test.vader
+++ b/test/util/ns_ast/ast-test.vader
@@ -146,3 +146,41 @@ Execute (Sorted Insert of literal into a :refer vector at beginning):
 Expect clojure (Properly indent new form):
   (ns serenity.core
     (:require [serenity.cargo :refer [beef geisha-dolls]]))
+
+
+"
+" =========================================================
+"
+
+Given clojure (ns with single :require and :as):
+  (ns serenity.core
+    (:require [serenity.cargo :as cargo]))
+
+Execute (Sorted Insert of keyword clause):
+  let ast = Build()
+  let vector = ast.FindClause('serenity.cargo')
+  call vector.SortedAddKeyPair(':refer', '[geisha-dolls]')
+  call Write(ast)
+
+Expect clojure (Insert :refer clause correctly):
+  (ns serenity.core
+    (:require [serenity.cargo :as cargo :refer [geisha-dolls]]))
+
+
+"
+" =========================================================
+"
+
+Given clojure (ns with single :require and :refer):
+  (ns serenity.core
+    (:require [serenity.cargo :refer [geisha-dolls]]))
+
+Execute (Sorted Insert of keyword clause):
+  let ast = Build()
+  let vector = ast.FindClause('serenity.cargo')
+  call vector.SortedAddKeyPair(':as', 'cargo')
+  call Write(ast)
+
+Expect clojure (Insert :as clause correctly):
+  (ns serenity.core
+    (:require [serenity.cargo :as cargo :refer [geisha-dolls]]))

--- a/test/util/ns_ast/ast-test.vader
+++ b/test/util/ns_ast/ast-test.vader
@@ -130,6 +130,28 @@ Expect clojure (Properly indent new form):
 " =========================================================
 "
 
+Given clojure (Multi- :require ns):
+  (ns serenity.core
+    (:require [clojure.string :as str]
+              [serenity.util :as util]))
+
+Execute (Add vector to middle of :require form):
+  let ast = Build()
+  let require = ast.FindClause(':require')
+  call require.SortedInsertLiteral('[serenity.cargo :as cargo]')
+  call Write(ast)
+
+Expect clojure (Properly indent new form):
+  (ns serenity.core
+    (:require [clojure.string :as str]
+              [serenity.cargo :as cargo]
+              [serenity.util :as util]))
+
+
+"
+" =========================================================
+"
+
 Given clojure (Single :require ns on its own line):
   (ns serenity.core
     (:require

--- a/test/util/ns_ast/ast-test.vader
+++ b/test/util/ns_ast/ast-test.vader
@@ -270,3 +270,25 @@ Expect clojure (Properly indent new form):
                [cargo :as cargo]
                [util :as util]]))
 
+"
+" =========================================================
+"
+
+Given clojure (ns with comments):
+  (ns serenity.core
+    (:require ; [serenity.cargo :refer [geisha-dolls]]
+              #_[serenity.cargo :refer [beef]]
+              [serenity.cargo :as cargo :refer [#_medicine]])
+    #_(:import Alliance))
+
+Execute (Append vector to nested :require form):
+"   call Write(Build())
+  call Build()
+
+Expect clojure (Rebuild without changes):
+  (ns serenity.core
+    (:require ; [serenity.cargo :refer [geisha-dolls]]
+              #_[serenity.cargo :refer [beef]]
+              [serenity.cargo :as cargo :refer [#_medicine]])
+    #_(:import Alliance))
+

--- a/test/util/ns_ast/ast-test.vader
+++ b/test/util/ns_ast/ast-test.vader
@@ -33,12 +33,13 @@ Given clojure (ns with single :require):
   (ns serenity.core
     (:require [serenity.cargo :as cargo]))
 
-Execute (Build AST and find serenity.cargo require clause):
+Execute (Build AST and find serenity.cargo require clause, :as arg):
   let ast = Build()
   let vector = ast.FindClause('serenity.cargo')
   AssertEqual v:t_dict, type(vector)
   AssertEqual 'vector', vector.type
   AssertEqual 'form', vector.parent.type
+  AssertEqual 'cargo', vector.FindKeywordValue(':as').value
 
 
 "
@@ -127,3 +128,21 @@ Expect clojure (Properly indent new form):
       [serenity.util :as util]))
 
 
+"
+" =========================================================
+"
+
+Given clojure (ns with single :require and :refer):
+  (ns serenity.core
+    (:require [serenity.cargo :refer [geisha-dolls]]))
+
+Execute (Sorted Insert of literal into a :refer vector at beginning):
+  let ast = Build()
+  let vector = ast.FindClause('serenity.cargo')
+  let refer = vector.FindKeywordValue(':refer')
+  call refer.SortedInsertLiteral('beef')
+  call Write(ast)
+
+Expect clojure (Properly indent new form):
+  (ns serenity.core
+    (:require [serenity.cargo :refer [beef geisha-dolls]]))

--- a/test/util/ns_ast/tokenizer-test.vader
+++ b/test/util/ns_ast/tokenizer-test.vader
@@ -64,7 +64,7 @@ Execute (Get tokens):
   AssertEqual ['ws', ' '], tok.Next()
   AssertEqual ['string', 'Mal Reynolds'], tok.Next()
   AssertEqual ['}', '}'], tok.Next()
-  AssertEqual ['ws', '\n'], tok.Next()
+  AssertEqual ['ws', "\n"], tok.Next()
 
   AssertEqual ['ws', '  '], tok.Next()
   AssertEqual ['sym', 'serenity.core'], tok.Next()

--- a/test/util/ns_ast/tokenizer-test.vader
+++ b/test/util/ns_ast/tokenizer-test.vader
@@ -106,3 +106,62 @@ Execute (Preserve Col value with Peek):
   AssertEqual 3, tok.Col()
   AssertEqual ['ws', ' '], tok.Peek()
   AssertEqual 3, tok.Col()
+
+
+"
+" =========================================================
+"
+
+Given clojure (Simple ns with commented-out forms):
+  (ns serenity.core
+    (:require ; [serenity.cargo :refer [geisha-dolls]]
+              #_[serenity.cargo :refer [beef]]
+              #_["impossible]@name" :default impossible]
+              [serenity.cargo :as cargo :refer [#_medicine]])
+    #_(:import Alliance))
+
+Execute (Get tokens):
+  let tok = Tokenizer()
+  AssertEqual 0, tok.col
+  AssertEqual ['(', '('], tok.Next()
+  AssertEqual ['sym', 'ns'], tok.Next()
+  AssertEqual ['ws', ' '], tok.Next()
+  AssertEqual ['sym', 'serenity.core'], tok.Next()
+  AssertEqual ['ws', "\n"], tok.Next()
+
+  AssertEqual ['ws', '  '], tok.Next()
+  AssertEqual ['(', '('], tok.Next()
+  AssertEqual ['kw', ':require'], tok.Next()
+  AssertEqual ['ws', ' '], tok.Next()
+  AssertEqual ['comment', '; [serenity.cargo :refer [geisha-dolls]]'], tok.Next()
+  AssertEqual ['ws', "\n"], tok.Next()
+
+  AssertEqual ['ws', '            '], tok.Next()
+  AssertEqual ['commented', '#_[serenity.cargo :refer [beef]]'], tok.Next()
+  AssertEqual ['ws', "\n"], tok.Next()
+
+  AssertEqual ['ws', '            '], tok.Next()
+  AssertEqual ['commented', '#_["impossible]@name" :default impossible]'], tok.Next()
+  AssertEqual ['ws', "\n"], tok.Next()
+
+  AssertEqual ['ws', '            '], tok.Next()
+  AssertEqual ['[', '['], tok.Next()
+  AssertEqual ['sym', 'serenity.cargo'], tok.Next()
+  AssertEqual ['ws', ' '], tok.Next()
+  AssertEqual ['kw', ':as'], tok.Next()
+  AssertEqual ['ws', ' '], tok.Next()
+  AssertEqual ['sym', 'cargo'], tok.Next()
+  AssertEqual ['ws', ' '], tok.Next()
+  AssertEqual ['kw', ':refer'], tok.Next()
+  AssertEqual ['ws', ' '], tok.Next()
+  AssertEqual ['[', '['], tok.Next()
+  AssertEqual ['commented', '#_medicine'], tok.Next()
+  AssertEqual [']', ']'], tok.Next()
+  AssertEqual [']', ']'], tok.Next()
+  AssertEqual [')', ')'], tok.Next()
+  AssertEqual ['ws', "\n"], tok.Next()
+
+  AssertEqual ['ws', '  '], tok.Next()
+  AssertEqual ['commented', '#_(:import Alliance)'], tok.Next()
+  AssertEqual [')', ')'], tok.Next()
+  AssertEqual ['end', ''], tok.Next()

--- a/test/util/ns_ast/tokenizer-test.vader
+++ b/test/util/ns_ast/tokenizer-test.vader
@@ -12,10 +12,19 @@ Given clojure (Empty ns):
 
 Execute (Get tokens):
   let tok = Tokenizer()
+  AssertEqual 0, tok.col
   AssertEqual ['(', '('], tok.Next()
+
+  AssertEqual 1, tok.col
   AssertEqual ['sym', 'ns'], tok.Next()
+
+  AssertEqual 3, tok.col
   AssertEqual ['ws', ' '], tok.Next()
+
+  AssertEqual 4, tok.col
   AssertEqual ['sym', 'serenity.core'], tok.Next()
+
+  AssertEqual 17, tok.col
   AssertEqual [')', ')'], tok.Next()
   AssertEqual ['end', ''], tok.Next()
 
@@ -38,10 +47,11 @@ Given clojure (Fancy string literal):
   "Mal \"Captain\"
   Reynolds"
 
-Execute (Get tokens):
+Execute (Get tokens from multi-line string):
   let tok = Tokenizer()
   " NOTE: let's keep the escaped quotes for simplicity when rebuilding
   AssertEqual ['string', 'Mal \"Captain\"' . "\n" . 'Reynolds'], tok.Next()
+  AssertEqual 9, tok.col
 
 
 "
@@ -66,7 +76,33 @@ Execute (Get tokens):
   AssertEqual ['}', '}'], tok.Next()
   AssertEqual ['ws', "\n"], tok.Next()
 
+  AssertEqual 0, tok.col
   AssertEqual ['ws', '  '], tok.Next()
+
+  AssertEqual 2, tok.col
   AssertEqual ['sym', 'serenity.core'], tok.Next()
   AssertEqual [')', ')'], tok.Next()
   AssertEqual ['end', ''], tok.Next()
+
+
+"
+" =========================================================
+"
+
+Given clojure (Empty Ns with simple meta):
+  (ns ^{:author "Mal Reynolds"}
+    serenity.core)
+
+Execute (Preserve Col value with Peek):
+  let tok = Tokenizer()
+  AssertEqual 0, tok.Col()
+  AssertEqual ['(', '('], tok.Next()
+
+  AssertEqual 1, tok.Col()
+  AssertEqual ['sym', 'ns'], tok.Peek()
+  AssertEqual 1, tok.Col()
+  AssertEqual ['sym', 'ns'], tok.Next()
+
+  AssertEqual 3, tok.Col()
+  AssertEqual ['ws', ' '], tok.Peek()
+  AssertEqual 3, tok.Col()

--- a/test/util/ns_ast/tokenizer-test.vader
+++ b/test/util/ns_ast/tokenizer-test.vader
@@ -1,0 +1,72 @@
+Execute (Provide util fns):
+  func! Tokenizer()
+    return hearth#util#ns_ast#tokenizer(getline(0, line('$')))
+  endfunc
+
+"
+" =========================================================
+"
+
+Given clojure (Empty ns):
+  (ns serenity.core)
+
+Execute (Get tokens):
+  let tok = Tokenizer()
+  AssertEqual ['(', '('], tok.Next()
+  AssertEqual ['sym', 'ns'], tok.Next()
+  AssertEqual ['ws', ' '], tok.Next()
+  AssertEqual ['sym', 'serenity.core'], tok.Next()
+  AssertEqual [')', ')'], tok.Next()
+  AssertEqual ['end', ''], tok.Next()
+
+"
+" =========================================================
+"
+
+Given clojure (Simple string literal):
+  "Mal Reynolds"
+
+Execute (Get tokens):
+  let tok = Tokenizer()
+  AssertEqual ['string', 'Mal Reynolds'], tok.Next()
+
+"
+" =========================================================
+"
+
+Given clojure (Fancy string literal):
+  "Mal \"Captain\"
+  Reynolds"
+
+Execute (Get tokens):
+  let tok = Tokenizer()
+  " NOTE: let's keep the escaped quotes for simplicity when rebuilding
+  AssertEqual ['string', 'Mal \"Captain\"' . "\n" . 'Reynolds'], tok.Next()
+
+
+"
+" =========================================================
+"
+
+Given clojure (Empty Ns with simple meta):
+  (ns ^{:author "Mal Reynolds"}
+    serenity.core)
+
+Execute (Get tokens):
+  let tok = Tokenizer()
+  AssertEqual ['(', '('], tok.Next()
+  AssertEqual ['sym', 'ns'], tok.Next()
+  AssertEqual ['ws', ' '], tok.Next()
+
+  AssertEqual ['meta', '^'], tok.Next()
+  AssertEqual ['{', '{'], tok.Next()
+  AssertEqual ['kw', ':author'], tok.Next()
+  AssertEqual ['ws', ' '], tok.Next()
+  AssertEqual ['string', 'Mal Reynolds'], tok.Next()
+  AssertEqual ['}', '}'], tok.Next()
+  AssertEqual ['ws', '\n'], tok.Next()
+
+  AssertEqual ['ws', '  '], tok.Next()
+  AssertEqual ['sym', 'serenity.core'], tok.Next()
+  AssertEqual [')', ')'], tok.Next()
+  AssertEqual ['end', ''], tok.Next()


### PR DESCRIPTION
Closes #1 

In addition to (hopefully) being more reliable, this makes ns refactorings more maintainable and featureful. For example, we can now infer the use of `()` instead of `[]` for `:refer` clauses, based on other uses in the file. Adding support for java imports should also be relatively simple (assuming we can get appropriate suggestions) using the same AST tools we built here.